### PR TITLE
fslist: search by selinux labels

### DIFF
--- a/lustre_lov.h
+++ b/lustre_lov.h
@@ -22,6 +22,9 @@
 #ifndef EXT2_XATTR_INDEX_LUSTRE
 #define EXT2_XATTR_INDEX_LUSTRE		5
 #endif
+#ifndef EXT2_XATTR_INDEX_SECURITY
+#define EXT2_XATTR_INDEX_SECURITY	6
+#endif
 
 /* From lustre_idl.h */
 #define LOV_MAGIC_V1	0x0BD10BD0


### PR DESCRIPTION
Hello,

Recently at the CEA we needed to find all file matching "unlabeled_t" selinux label on several filesystems. Those file had not been properly labeled due to incompatible selinux configurations on the clients.
"find -context" was to slow for us, so I have modified lester to find those files.

Here the patch that we used. 